### PR TITLE
#28 implemented lib function for getting all regions as vector of strings

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -88,8 +88,17 @@ pub fn get_region_by_generation(id: usize) -> String {
         7 => Generation::Alola,
         8 => Generation::Galar,
         9 => Generation::Paldea,
-        _ => panic!("Invalid input")
+        _ => panic!("Invalid input"),
     };
 
     return gen.to_string();
+}
+
+// TODO: need support for generations in different locales
+pub fn get_all_regions() -> Vec<String> {
+    let all_regions = (1..=9)
+        .map(|x| get_region_by_generation(x))
+        .collect::<Vec<String>>();
+
+    return all_regions;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ pub fn get_generation<'a>(generation: &str, locale: Option<&'a str>) -> Vec<&'a 
 pub fn get_region(generation_number: usize) -> String {
     functions::get_region_by_generation(generation_number)
 }
+pub fn get_all_regions() -> Vec<String> {
+    functions::get_all_regions()
+}
 
 #[cfg(test)]
 mod test;

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -1,4 +1,4 @@
-use crate::{get_all, get_generation, get_region};
+use crate::{functions::get_all_regions, get_all, get_generation, get_region};
 
 fn type_to_string<T>(_: &T) -> String {
     format!("{}", std::any::type_name::<T>())
@@ -77,5 +77,10 @@ fn test_verify_all_nine_regions_works() {
     let start = range.start as usize;
     let end = range.end as usize;
     let all_regions = (start..end).map(|f| vec.push(get_region(f)));
+    assert_eq!(9, all_regions.len());
+}
+#[test]
+fn test_get_all_regions() {
+    let all_regions = get_all_regions();
     assert_eq!(9, all_regions.len());
 }


### PR DESCRIPTION
saves consumers the work of asking the lib for all 9 regions separately and returning all as `Vec<String>`